### PR TITLE
Run install in directories where package[-lock].json changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "post-merge-install",
   "version": "0.1.0",
-  "description": "Run NPM Install post merge - Husky Hook",
+  "description": "A husky-hook to run 'npm install' post merge",
   "bin": {
     "post-merge-install": "./post-merge.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "post-merge-install",
   "version": "0.1.0",
-  "description": "A husky-hook to run 'npm install' post merge",
+  "description": "A hook to run 'npm install' post-merge via husky 🐶",
   "bin": {
     "post-merge-install": "./post-merge.js"
   },
@@ -16,7 +16,8 @@
   },
   "keywords": [
     "husky",
-    "npm hook",
+    "git hook",
+    "npm install",
     "post-merge",
     "cleartax"
   ],

--- a/post-merge.js
+++ b/post-merge.js
@@ -1,24 +1,37 @@
 #!/usr/bin/env node
-const { execSync, spawn } = require('child_process')
+const { execSync, spawn } = require('child_process');
+const { dirname, resolve } = require('path');
 const chalk = require('chalk');
+const { getDirectoriesToInstall, spawnProcess } = require('./utils');
+
+const workingDirectory = process.cwd();
 
 (async () => {
-  const diffTree = execSync('git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD').toString()
+  const diffTree = execSync('git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD').toString();
+  const packageFiles = getPackageFiles(diffTree);
 
-  const filesChanged = (diffTree || '').split('\n').filter(Boolean)
-  const needsInstall =
-    !process.env.CI && filesChanged.some(file => file === 'package.json' || file === 'package-lock.json')
+  const filesChanged = (diffTree || '').split('\n').filter(Boolean);
+  const needsInstall = !process.env.CI && packageFiles.length;
 
   if (needsInstall) {
     console.log(
       chalk.yellow(`
-        Detected changes in "${chalk.bold('package.json')}" or "${chalk.bold('package-lock.json')}".
-        Running "${chalk.bold('npm install')}" for you ..
-      `)
-    )
-    const npmInstall = spawn(`npm`, ['install'], { stdio: 'inherit' })
-    npmInstall.on('close', returnCode => {
-      process.exit(returnCode)
-    })
+Detected changes in "${chalk.bold('package.json')}" or "${chalk.bold('package-lock.json')}".
+Running "${chalk.bold('npm install')}" in the corresponding directories..
+\n\n`)
+    );
+
+    const directories = getDirectoriesToInstall(filesChanged);
+
+    try {
+      for (const directory of directories) {
+        await spawn(`npm`, ['install'], {
+            cwd: resolve(workingDirectory, directory),
+            stdio: 'inherit' });
+      }
+    } catch (e) {
+      console.error(e);
+      process.exit(1);
+    }
   }
 })()

--- a/post-merge.js
+++ b/post-merge.js
@@ -2,24 +2,23 @@
 const { execSync, spawn } = require('child_process');
 const { dirname, resolve } = require('path');
 const chalk = require('chalk');
-const { getDirectoriesToInstall, spawnProcess, getPackageFiles } = require('./utils');
+const { getDirectoriesToInstall, getPackageFiles } = require('./utils');
 
 (async () => {
   const diffTree = execSync('git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD').toString().trim();
   const gitRoot = execSync('git rev-parse --show-toplevel').toString().trim();
-  const packageFiles = getPackageFiles(diffTree);
 
-  const filesChanged = diffTree.split('\n').filter(Boolean);
-  const needsInstall = !process.env.CI && packageFiles.length;
+  const changedPackageFiles = getPackageFiles(diffTree);
+  const needsInstall = !process.env.CI && changedPackageFiles.length;
 
   if (needsInstall) {
     console.log(
       chalk.yellow(`
-Detected changes in "${chalk.bold('package.json')}" or "${chalk.bold('package-lock.json')}".
+Detected changes in "${chalk.bold('package.json')}" and/or "${chalk.bold('package-lock.json')}".
 Running "${chalk.bold('npm install')}" in the corresponding directories..\n`)
     );
 
-    const directories = getDirectoriesToInstall(filesChanged);
+    const directories = getDirectoriesToInstall(changedPackageFiles);
 
     try {
       for (const directory of directories) {

--- a/post-merge.js
+++ b/post-merge.js
@@ -5,11 +5,11 @@ const chalk = require('chalk');
 const { getDirectoriesToInstall, spawnProcess, getPackageFiles } = require('./utils');
 
 (async () => {
-  const diffTree = execSync('git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD').toString();
-  const gitRoot = execSync('git rev-parse --show-toplevel').toString();
+  const diffTree = execSync('git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD').toString().trim();
+  const gitRoot = execSync('git rev-parse --show-toplevel').toString().trim();
   const packageFiles = getPackageFiles(diffTree);
 
-  const filesChanged = (diffTree || '').split('\n').filter(Boolean);
+  const filesChanged = diffTree.split('\n').filter(Boolean);
   const needsInstall = !process.env.CI && packageFiles.length;
 
   if (needsInstall) {

--- a/utils.js
+++ b/utils.js
@@ -21,8 +21,3 @@ exports.unique = arr => Array.isArray(arr) ? [...new Set(arr)] : [];
  * @param {String[]}
  */
 exports.getDirectoriesToInstall = (files = []) => Array.isArray(files) ? exports.unique(files.map(file => dirname(file))) : [];
-
-exports.spawnProcess = (...args) => new Promise((resolve, reject) => {
-  const spawned = spawn(...args);
-  spawned.on('close', (returnCode) => returnCode ? reject(returnCode) : resolve(returnCode));
-});

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,28 @@
+const { dirname } = require('path');
+const { spawn } = require('child_process');
+
+const PACKAGE_FILE = /package(-lock)?\.json/;
+
+/**
+ * Returns filtered list of files from the diff-tree which are either `package.json` or `package-lock.json`
+ * @param {String} diffTree - results of git diff-tree as string
+ */
+exports.getPackageFiles = (diffTree = '') => diffTree.split('\n').filter(file => PACKAGE_FILE.test(file));
+
+/**
+ * Retuns unique list of items from an array
+ * @param {Array} arr
+ * @see https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_uniq
+ */
+exports.unique = arr => Array.isArray(arr) ? [...new Set(arr)] : [];
+
+/**
+ * Given a list of file paths, returns the unique list of directories they are in.
+ * @param {String[]}
+ */
+exports.getDirectoriesToInstall = (files = []) => Array.isArray(files) ? exports.unique(files.map(file => dirname(file))) : [];
+
+exports.spawnProcess = (...args) => new Promise((resolve, reject) => {
+  const spawned = spawn(...args);
+  spawned.on('close', (returnCode) => returnCode ? reject(returnCode) : resolve(returnCode));
+});


### PR DESCRIPTION
## Description
Add support for running `npm install` in any directory which contains the changed `package[-lock].json` file.

to make post-merge-install work when:
- you run merge/pull in any subdirectory
- in mono-repo