### PR TITLE
Option --prompt: Confirm before running `npm install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,18 @@ or globally as
 
 ### Options
 
-| Option                         | Description     | Details |
-|--------------------------------|-----------------|---------|
-|`--auto-install`                |Disables confirmation prompt and automatically installs packages if change in `package.json` or `package-lock` is detected.| User will be prompted if flag is not passed|
+<table>
+  <thead>
+    <th>Flag</th>
+    <th>Description</th>
+    <th>Details</th>
+  </thead>
+  <tbody>
+    <td width='200'><code>--auto-install</code></td>
+    <td>Disables confirmation prompt and automatically installs packages if change in `package.json` or `package-lock`is detected.</td>
+    <td>By default <code>post-merge-install</code> will prompt the user if an <code>npm install</code> should be done. This flag disables this confirmation prompt and always installs dependecies if a change is detected.</td>
+  </tbody>
+</table>
 
 ### Alias
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ or globally as
 }
 ```
 
+### Options
+
+| Flag           | Description                                                                                                                                                                                                                                                                                                               |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --auto-install | Disables confirmation prompt and automatically installs packages if change in `package.json` or `package-lock`is detected. By default `post-merge-install` will prompt the user if an `npm install` should be done. This flag disables this confirmation prompt and always installs dependecies if a change is detected. |
+
 ### Alias
 
 You can also use the alias `pmi` instead of `post-merge-install`

--- a/README.md
+++ b/README.md
@@ -29,18 +29,9 @@ or globally as
 
 ### Options
 
-<table>
-  <thead>
-    <th>Flag</th>
-    <th>Description</th>
-    <th>Details</th>
-  </thead>
-  <tbody>
-    <td style='min-width: 120px'>`--auto-install`</td>
-    <td>Disables confirmation prompt and automatically installs packages if change in `package.json` or `package-lock`is detected.</td>
-    <td>By default `post-merge-install` will prompt the user if an `npm install` should be done. This flag disables this confirmation prompt and always installs dependecies if a change is detected.</td>
-  </tbody>
-</table>
+| Option                         | Description     | Details |
+|--------------------------------|-----------------|---------|
+|`--auto-install` |Disables confirmation prompt and automatically installs packages if change in `package.json` or `package-lock` is detected.| User will be prompted if flag is not passed|
 
 ### Alias
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ or globally as
     <th>Details</th>
   </thead>
   <tbody>
-    <td width='200'><code>--auto-install</code></td>
-    <td>Disables confirmation prompt and automatically installs packages if change in `package.json` or `package-lock`is detected.</td>
-    <td>By default <code>post-merge-install</code> will prompt the user if an <code>npm install</code> should be done. This flag disables this confirmation prompt and always installs dependecies if a change is detected.</td>
+    <td width='200'><code>--prompt</code></td>
+    <td>Enables a confirmation prompt before installing packages if change in `package.json` or `package-lock`is detected.</td>
+    <td>By default <code>post-merge-install</code> automatically installs dependencies if a change is detected. Adding this flag enables a confirmation prompt asking if an <code>npm install</code> should be done</td>
   </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ or globally as
   </thead>
   <tbody>
     <td width='200'><code>--prompt</code></td>
-    <td>Enables a confirmation prompt before installing packages if change in `package.json` or `package-lock`is detected.</td>
-    <td>By default <code>post-merge-install</code> automatically installs dependencies if a change is detected. Adding this flag enables a confirmation prompt asking if an <code>npm install</code> should be done</td>
+    <td>Enables a confirmation prompt before installing packages if change in <code>package.json</code> or <code>package-lock.json</code> is detected.</td>
+    <td>By default <code>post-merge-install</code> automatically installs dependencies if a change is detected. Adding this flag enables a confirmation prompt asking if an <code>npm install</code> should be run.</td>
   </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ or globally as
 
 | Option                         | Description     | Details |
 |--------------------------------|-----------------|---------|
-|`--auto-install` |Disables confirmation prompt and automatically installs packages if change in `package.json` or `package-lock` is detected.| User will be prompted if flag is not passed|
+|`--auto-install`                |Disables confirmation prompt and automatically installs packages if change in `package.json` or `package-lock` is detected.| User will be prompted if flag is not passed|
 
 ### Alias
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,18 @@ or globally as
 
 ### Options
 
-| Flag           | Description                                                                                                                                                                                                                                                                                                               |
-|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| --auto-install | Disables confirmation prompt and automatically installs packages if change in `package.json` or `package-lock`is detected. By default `post-merge-install` will prompt the user if an `npm install` should be done. This flag disables this confirmation prompt and always installs dependecies if a change is detected. |
+<table>
+  <thead>
+    <th>Flag</th>
+    <th>Description</th>
+    <th>Details</th>
+  </thead>
+  <tbody>
+    <td style='min-width: 120px'>`--auto-install`</td>
+    <td>Disables confirmation prompt and automatically installs packages if change in `package.json` or `package-lock`is detected.</td>
+    <td>By default `post-merge-install` will prompt the user if an `npm install` should be done. This flag disables this confirmation prompt and always installs dependecies if a change is detected.</td>
+  </tbody>
+</table>
 
 ### Alias
 

--- a/installPrompt.sh
+++ b/installPrompt.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+# Re-enables the keyboard input (https://github.com/typicode/husky/issues/597)
 exec < /dev/tty
 
 read -n1 -p "Run npm install? (y/n): " ANSWER 

--- a/installPrompt.sh
+++ b/installPrompt.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+exec < /dev/tty
+
+read -n1 -p "Run npm install? (y/n) " ANSWER 
+case $ANSWER in  
+  y|Y) exit 0 ;; 
+  n|N) exit 1 ;; 
+esac
+
+exit 0

--- a/installPrompt.sh
+++ b/installPrompt.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 exec < /dev/tty
 
-read -n1 -p "Run npm install? (y/n) " ANSWER 
+read -n1 -p "Run npm install? (y/n): " ANSWER 
+echo '' # For the new line
+
 case $ANSWER in  
   y|Y) exit 0 ;; 
   n|N) exit 1 ;; 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "homepage": "https://github.com/ClearTax/post-merge-install#readme",
   "dependencies": {
-    "chalk": "^2.4.2"
+    "chalk": "^2.4.2",
+    "inquirer": "^7.0.0"
   },
   "devDependencies": {
     "prepublish-ok": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   },
   "homepage": "https://github.com/ClearTax/post-merge-install#readme",
   "dependencies": {
-    "chalk": "^2.4.2",
-    "inquirer": "^7.0.0"
+    "chalk": "^2.4.2"
   },
   "devDependencies": {
     "prepublish-ok": "^0.4.0",

--- a/post-merge.js
+++ b/post-merge.js
@@ -3,12 +3,7 @@ const { execSync } = require('child_process')
 const { resolve } = require('path')
 const chalk = require('chalk')
 const { getDirectoriesToInstall, getPackageFiles } = require('./utils');
-const readline = require('readline');
-
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout
-});
+const inquirer = require('inquirer');
 
 (async() => {
   const cliOptions = process.argv.reduce((agg, arg) => {
@@ -30,19 +25,19 @@ const rl = readline.createInterface({
 
     if (!cliOptions['--auto-install']) {
       try {
-        await new Promise((resolve, reject) => {
-          rl.question('Re-install depedencies? (y/n)', (answer) => {
-            rl.close();
-    
-            if (answer === 'y' || answer === 'Y') {
-              resolve();
-            }
+        const answers = await inquirer
+          .prompt([{
+            type: 'confirm',
+            message: 'Do you want to run `npm install` now?',
+            name: 'installConfirmation'
+          }]);
 
-            reject();
-          });
-        });
+        if (!answers.installConfirmation) {
+          process.exit(0);
+        }
       } catch (err) {
-        return;
+        console.error('Error getting user input: ', e);
+        process.exit(1);
       }
     }
 

--- a/post-merge.js
+++ b/post-merge.js
@@ -24,7 +24,7 @@ const rl = readline.createInterface({
       chalk.yellow(`Detected changes in "${chalk.bold('package.json')}" and/or "${chalk.bold('package-lock.json')}".`)
     )
 
-    if (!cliOptions['--auto-install']) {
+    if (cliOptions['--prompt']) {
       const answer = spawnSync(`${__dirname}/installPrompt.sh`, {
         timeout: 5000,
         stdio: 'inherit',

--- a/post-merge.js
+++ b/post-merge.js
@@ -2,7 +2,7 @@
 const { execSync, spawnSync } = require('child_process')
 const { resolve } = require('path')
 const chalk = require('chalk')
-const { getDirectoriesToInstall, getPackageFiles } = require('./utils');
+const { getDirectoriesToInstall, getPackageFiles, parseCliOptions } = require('./utils');
 const readline = require('readline');
 
 const rl = readline.createInterface({
@@ -11,11 +11,7 @@ const rl = readline.createInterface({
 });
 
 (async() => {
-  const cliOptions = process.argv.reduce((agg, arg) => {
-    const [flag, value] = arg.split('=');
-    agg[flag] = value || flag;
-    return agg;
-  }, {});
+  const cliOptions = parseCliOptions();
 
   const diffTree = execSync('git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD').toString().trim();
   const gitRoot = execSync('git rev-parse --show-toplevel').toString().trim();

--- a/post-merge.js
+++ b/post-merge.js
@@ -29,6 +29,8 @@ const rl = readline.createInterface({
     )
 
     if (!cliOptions['--auto-install']) {
+      execSync('exec < /dev/tty');
+
       try {
         await Promise
           .race([

--- a/post-merge.js
+++ b/post-merge.js
@@ -29,7 +29,9 @@ const rl = readline.createInterface({
     )
 
     if (!cliOptions['--auto-install']) {
-      execSync('exec < /dev/tty');
+      execSync('exec < /dev/tty', {
+        stdio: 'inherit',
+      });
 
       try {
         await Promise

--- a/post-merge.js
+++ b/post-merge.js
@@ -29,12 +29,16 @@ const rl = readline.createInterface({
     )
 
     if (!cliOptions['--auto-install']) {
-      execSync('chmod +x ./installPrompt.sh');
-      const answer = spawnSync('./installPrompt.sh', {
+      const answer = spawnSync(`${__dirname}/installPrompt.sh`, {
+        timeout: 5000,
         stdio: 'inherit',
+        killSignal: 1,
       });
 
       if (answer.status !== 0) {
+        if (answer.signal === 'SIGHUP') {
+          console.log('No user input detected. Exiting...');
+        }
         process.exit(0);
       }
     }

--- a/utils.js
+++ b/utils.js
@@ -34,13 +34,19 @@ exports.parseCliOptions = () => {
         if (value) {
             // To handle boolean values passed as string
             switch (value) {
-                case 'true':
+                case 'true': {
+                    agg[flag] = true;
+                    break;
+                }
+
                 case 'false': {
-                    agg[flag] = eval(value);
+                    agg[flag] = false;
+                    break;
                 }
 
                 default: {
                     agg[flag] = value;
+                    break;
                 }
             }
         } else {

--- a/utils.js
+++ b/utils.js
@@ -20,3 +20,18 @@ exports.unique = arr => Array.isArray(arr) ? [...new Set(arr)] : []
  * @param {String[]}
  */
 exports.getDirectoriesToInstall = (files = []) => Array.isArray(files) ? exports.unique(files.map(file => dirname(file))) : []
+
+/**
+ * Takes an array of cli arguments and returns an object of parsed keys along with values (if provided)
+ * Example: foo --bar will return { 'foo': 'foo', 'bar': 'bar'}
+ * Example: foo --bar=123 will return { 'foo': 'foo', 'bar': '123'}
+ * @param {Array} arr
+ * @returns {Object}
+ */
+exports.parseCliOptions = () => {
+    process.argv.reduce((agg, arg) => {
+        const [flag, value] = arg.split('=');
+        agg[flag] = value || flag;
+        return agg;
+    }, {});
+}

--- a/utils.js
+++ b/utils.js
@@ -29,9 +29,24 @@ exports.getDirectoriesToInstall = (files = []) => Array.isArray(files) ? exports
  * @returns {Object}
  */
 exports.parseCliOptions = () => {
-    process.argv.reduce((agg, arg) => {
+    return process.argv.reduce((agg, arg) => {
         const [flag, value] = arg.split('=');
-        agg[flag] = value || flag;
+        if (value) {
+            // To handle boolean values passed as string
+            switch (value) {
+                case 'true':
+                case 'false': {
+                    agg[flag] = eval(value);
+                }
+
+                default: {
+                    agg[flag] = value;
+                }
+            }
+        } else {
+            agg[flag] = true;
+        }
+        
         return agg;
     }, {});
 }


### PR DESCRIPTION
## Summary

### What does this PR add?

This PR makes automatic installs of dependencies **opt-in**.

### What does this solve?

Currently post-merge-install _automatically_ re-installs packages if `package.json` or `package-lock.json` have been modified.

Auto-install may have some unintended consequences on a person's development workflow - say for instance the dev has made some local changes to a npm module and a simple pull or merge removes said changes.

### What is the change?

~1. Adds a prompt for the developer to choose whether he/she wants to re-install the packages if a change has been detected.
2. Adds support for a `--auto-install` flag that can be passed to the cli to maintain the current behaviour.~ 

(Please see edit on 8th November)

**[Edit: 8th November, 2019]**

As discussed [in this comment](https://github.com/ClearTax/post-merge-install/pull/3#issuecomment-551083455), flipping the changes in this PR.

1. Adds support for a `--prompt` flag that can be passed to the cli to prompt users before installing dependencies if a change is detected.